### PR TITLE
[feat]:전역 글꼴, 색상 추가, 공통버튼에 전역색상 적용(#4)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,23 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
+
+/* 앱 전체에 Pretendard 글꼴 적용*/
+body,
+#app,
+button,
+input,
+textarea,
+select {
+  font-family: "Pretendard", sans-serif;
+}
+/* 
+변수로 색깔 사용!
+button { background:var(--color-yellow-light);
+*/
+:root {
+  --color-yellow-light: #ffbc00;
+  --color-yellow-dark: #fcaf17;
+  --color-white: white;
+  --color-black: black;
+  --color-income: #00bf64;
+  --color-expense: #ff0000;
+}

--- a/src/components/common/CommonButton.vue
+++ b/src/components/common/CommonButton.vue
@@ -13,7 +13,7 @@ defineProps({
 
 <style scoped>
 button {
-  background-color: #ffbc00;
+  background-color: var(--color-yellow-dark);
   border-radius: 10px;
   border: none;
   color: white;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import './assets/main.css'
 
 const app = createApp(App)
 


### PR DESCRIPTION
<img width="722" height="444" alt="image" src="https://github.com/user-attachments/assets/294f6e2b-c591-406e-a4d0-ba00e9a7acf4" />

- 전역 글꼴(Pretendard) 추가
- 전역 색상 변수 추가
  - 앞으로 color 직접 입력하지 마시고 사진에 표시된 색깔변수로 개발 바랍니다